### PR TITLE
refactor: convert dashboard data handling

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -4,9 +4,10 @@ import ImplementationPlansInProgress from "../implementation-plan/Implementation
 import RecentInventoryLogs from "../inventory-management/RecentInventoryLogs";
 import NotificationsPanel from "../notifications/RecentNotifications";
 import NewServiceRequests from "../service-request/NewServiceRequests";
-import { fetchDashboardData } from "@/domains/dashboard/services/fetchDashboardData";
+// import { fetchDashboardData } from "@/domains/dashboard/services/fetchDashboardData";
 import { fetchUserRole } from "@/domains/user-management/services/fetchUserRole";
 import { useQuery } from "@tanstack/react-query";
+import { dashboardData as fetchDashboardData } from "@/lib/dashboard/dashboard-data";
 
 export default function Dashboard() {
   const { data: session } = useSession();
@@ -35,6 +36,21 @@ export default function Dashboard() {
   const errorMessage =
     dashboardError instanceof Error ? dashboardError.message : null;
 
+  // change this later
+  if (
+    !dashboardData?.data?.dashboardStats ||
+    !dashboardData?.data?.implementationPlans ||
+    !dashboardData.data.equipment ||
+    !dashboardData.data.newServiceRequests ||
+    !dashboardData.data.notifications
+  ) {
+    return (
+      <div>
+        Incomplete Data
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col w-full min-h-screen p-6 md:p-8 overflow-y-auto bg-gradient-to-b from-yellow-50 to-blue-100">
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-6">
@@ -48,11 +64,13 @@ export default function Dashboard() {
         </div>
       </div>
       <div className="mb-6">
-        <DashboardStats
-          stats={dashboardData?.dashboardStats}
-          isLoading={isLoading || userRoleLoading}
-          error={errorMessage}
-        />
+        ({dashboardData?.data?.dashboardStats && (
+          <DashboardStats
+            stats={dashboardData?.data?.dashboardStats}
+            isLoading={isLoading || userRoleLoading}
+            error={errorMessage}
+          />
+        )})
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
@@ -60,7 +78,14 @@ export default function Dashboard() {
           <div className="bg-white rounded-lg shadow overflow-hidden">
             <ImplementationPlansInProgress
               onUpdate={handlePlansUpdate}
-              implementationPlans={dashboardData?.implementationPlans}
+              implementationPlans={dashboardData?.data?.implementationPlans?.map((plan: any) => ({
+                ...plan,
+                serviceRequest: {
+                  requesterName: plan.serviceRequest.requesterName ?? "",
+                  createdOn: plan.serviceRequest.createdOn ?? new Date(),
+                  ...plan.serviceRequest,
+                },
+              }))}
               isLoading={isLoading || userRoleLoading}
               error={errorMessage}
               userRole={userRole as UserRole}
@@ -70,7 +95,7 @@ export default function Dashboard() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="bg-white rounded-lg shadow overflow-hidden h-full">
               <NewServiceRequests
-                newServiceRequests={dashboardData?.newServiceRequests?.slice(0,5)}
+                newServiceRequests={dashboardData?.data?.newServiceRequests?.slice(0, 5)}
                 isLoading={isLoading || userRoleLoading}
                 error={errorMessage}
               />
@@ -78,7 +103,7 @@ export default function Dashboard() {
 
             <div className="bg-white rounded-lg shadow overflow-hidden h-full">
               <RecentInventoryLogs
-                equipment={dashboardData?.equipment?.slice(0,6)}
+                equipment={dashboardData?.data.equipment?.slice(0, 6)}
                 isLoading={isLoading || userRoleLoading}
                 error={errorMessage}
               />
@@ -88,7 +113,7 @@ export default function Dashboard() {
 
         <div className="bg-white rounded-lg shadow overflow-hidden h-full">
           <NotificationsPanel
-            notifications={dashboardData?.notifications?.slice(0, 8)}
+            notifications={dashboardData?.data?.notifications?.slice(0, 8)}
             isLoading={isLoading || userRoleLoading}
             error={errorMessage}
           />

--- a/src/components/notifications/RecentNotifications.tsx
+++ b/src/components/notifications/RecentNotifications.tsx
@@ -68,7 +68,7 @@ export default function RecentNotifications({
   const groupedNotifications = isLoading
     ? []
     : notifications.reduce<Record<string, AdminNotification[]>>((acc, notification) => {
-        const dateLabel = getNotificationDateGroup(notification.createdAt)
+        const dateLabel = getNotificationDateGroup(notification.createdAt.toLocaleDateString())
         if (!acc[dateLabel]) {
           acc[dateLabel] = []
         }

--- a/src/domains/dashboard/services/getDashbaordData.ts
+++ b/src/domains/dashboard/services/getDashbaordData.ts
@@ -12,6 +12,9 @@ export async function getDashboardData(userId: string) {
     newServiceRequests,
     dashboardStats,
   ] = await Promise.all([
+    // these functions might cause too much query overhead bcos
+    // each function is checking the user id.
+    // subject to change
     getImplementationPlans(userId),
     getNotifications(userId),
     getPaginatedEquipment({ page: 1, pageSize: 15, userId }),

--- a/src/domains/implementation-plan/services/getImplementationPlans.ts
+++ b/src/domains/implementation-plan/services/getImplementationPlans.ts
@@ -37,6 +37,7 @@ export default async function getImplementationPlans(userId: string) {
       select: {
         id: true,
         description: true,
+        status: true,
         tasks: true,
         files: true,
         createdAt: true,

--- a/src/domains/notification/types/notificationType.d.ts
+++ b/src/domains/notification/types/notificationType.d.ts
@@ -9,8 +9,8 @@ type AdminNotification = {
   type: NotificationType;
   message: string;
   link: string;
-  department?: string;
-  supervisorId?: string;
+  department?: string | null;
+  supervisorId?: string | null;
   isRead: boolean;
-  createdAt: string;
+  createdAt: Date;
 }

--- a/src/domains/service-request/services/getPendingServiceRequests.ts
+++ b/src/domains/service-request/services/getPendingServiceRequests.ts
@@ -49,6 +49,7 @@ export async function getPendingServiceRequests(userId: string) {
    const createdOn = status.length > 0 ? status[0].timestamp : null;
    return {
      id,
+     user,
      requesterName,
      concern,
      details,

--- a/src/lib/ErrorCodes.ts
+++ b/src/lib/ErrorCodes.ts
@@ -51,4 +51,21 @@ export enum ErrorCodes {
    * functionality encounters an issue.
    */
   REGISTRATION_SUCCESS_BUT_MAIL_SEND_FAILURE = 69422,
+
+  /**
+   * Represents the status code indicating that the dashboard data fetch
+   * haas failed.
+   * 
+   * This can occur in scenarios where the user account does not exist
+   * or the given user id is somehow not valid.
+   */
+  DASHBOARD_ID_ERROR = 9000,
+
+  /**
+   * Represents a code or identifier for a dashboard failure event.
+   * This constant is used to indicate that a dashboard process has failed
+   * in the application logic. The value can be used for error handling,
+   * logging, or debugging purposes.
+   */
+  DASHBOARD_FAILURE = 9005,
 }

--- a/src/lib/dashboard/dashboard-data.ts
+++ b/src/lib/dashboard/dashboard-data.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import {ajv, validate} from "@/lib/validators/ajv";
+import { ErrorCodes } from "../ErrorCodes";
+import { getDashboardData } from "@/domains/dashboard/services/getDashbaordData";
+
+export async function dashboardData(userId: string) {
+  // Validation for Sanity Check
+  const validationResult = validate(ajv, { userId }, {
+    properties: {
+      userId: { type: "string", format: "non-empty-string-value" }
+    },
+    required: ["userId"],
+  })
+
+  if (!validationResult.ok) {
+    return {
+      code: ErrorCodes.DASHBOARD_ID_ERROR,
+      message: validationResult.messages.join(", ")
+    }
+  }
+
+  try {
+    const dashboardData = await getDashboardData(userId)
+
+    return {
+      code: ErrorCodes.OK,
+      data: dashboardData
+    }
+  } catch {
+    return {
+      code: ErrorCodes.DASHBOARD_FAILURE
+    }
+  }
+}


### PR DESCRIPTION
In this pull request, it aims to convert all API calls into Server Components.

## Progress in Conversion:

- [ ] `/auth`
    - [x] `login`
    - [x] `register`
    - [x] `reset-password`
    - [ ] `update-password`
    - [ ] `verify-email`
    - [ ] `verify-user`
- [x] `/dashboard`
- [ ] `/implmentation-plan/[id]`
- [ ] `/inventory-management`
- [ ] `/personnel-management`
- [ ] `/projects`
- [ ] `/service-request`
    - [ ] `[id]`
    - [ ] `archive`
    - [ ] `create`
        - [ ] `success`
- [ ] `/user-management`

This list is incomplete. This may add more stuff in the future.